### PR TITLE
implemented camera rotation and panning transition and plethora camera fixes

### DIFF
--- a/Assets/Scenes/DesignDoc.unity
+++ b/Assets/Scenes/DesignDoc.unity
@@ -7376,13 +7376,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 599639707}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -4.6600966}
+  m_LocalRotation: {x: 0.29357782, y: -0.20642203, z: 0.0650846, w: 0.9311101}
+  m_LocalPosition: {x: 1.94, y: 3.62, z: -4.18}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1510057399}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 35, y: -25, z: 0}
 --- !u!82 &599639709
 AudioSource:
   m_ObjectHideFlags: 0
@@ -7491,9 +7491,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3cc0cb634e7ca9f48b2c90bb087a6f4e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 1.5
+  speed: 3
   LevelManager: {fileID: 1704174257}
-  distFromPlayer: {x: -2.1, y: -3.7, z: 5.24}
+  isoCamera: {fileID: 1510057400}
+  _gameplayPos: {x: 0, y: 0, z: 0}
 --- !u!82 &599639711
 AudioSource:
   m_ObjectHideFlags: 0
@@ -7621,7 +7622,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: -5
   far clip plane: 1000
   field of view: 60
   orthographic: 1
@@ -10580,9 +10581,29 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: isoCamera
+      value: 
+      objectReference: {fileID: 1510057400}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
       propertyPath: LevelManager
       value: 
       objectReference: {fileID: 1704174257}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: cameraTransform
+      value: 
+      objectReference: {fileID: 1510057399}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: cameraWorldAxis
+      value: 
+      objectReference: {fileID: 1847892864}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: isoCameraTransform
+      value: 
+      objectReference: {fileID: 1510057399}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: cameraPanningRevertTarget
+      value: 
+      objectReference: {fileID: 599639710}
     - target: {fileID: 5616881381544338442, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -17523,6 +17544,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1510057399}
+  - component: {fileID: 1510057400}
   m_Layer: 0
   m_Name: Isometric Camera
   m_TagString: Untagged
@@ -17537,14 +17559,29 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1510057398}
-  m_LocalRotation: {x: 0.29357782, y: -0.20642203, z: 0.0650846, w: 0.9311101}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 599639708}
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 35, y: -25, z: 0}
+  m_Father: {fileID: 1847892864}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1510057400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510057398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfe4a5cdb09a5a3499b432a31cf38372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 1
+  isIntervteredControl: 0
+  LevelManager: {fileID: 1704174257}
 --- !u!1001 &1513166303
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21862,6 +21899,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8951452788856766230, guid: 7678c006a710d5a44abab66cfff1a5fa, type: 3}
   m_PrefabInstance: {fileID: 1847001675}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1847892863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1847892864}
+  m_Layer: 0
+  m_Name: WorldPivot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1847892864
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847892863}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1510057399}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1854442277
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ChangePerspective.cs
+++ b/Assets/Scripts/ChangePerspective.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ChangePerspective : MonoBehaviour
+{
+    public float rotationSpeed;
+    public bool isIntervteredControl;
+    public LevelManager LevelManager;
+    private float _target_y_angle;
+    private float _rot_dest;
+    private GameObject _player;
+    private bool _changingPersective;
+    // Start is called before the first frame update
+    void Start()
+    {
+        isIntervteredControl = false;
+        _target_y_angle = 180f;
+        _rot_dest = 180f;
+        _player = GameObject.FindWithTag("Player");
+        _changingPersective = false;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Q) || Input.GetKeyDown(KeyCode.E))
+        {
+            Debug.Log("changing persepctive");
+            _changingPersective = true;
+        }
+    }
+
+    void FixedUpdate() { 
+        if (_changingPersective)
+        {
+            transform.RotateAround(transform.parent.position, Vector3.up, _rot_dest * rotationSpeed * Time.deltaTime);
+            if (Mathf.Abs(Mathf.Abs(transform.rotation.eulerAngles.y) - _target_y_angle) < 0.1f)
+            {
+                _changingPersective = false;
+                if (transform.rotation.eulerAngles.y > 0)
+                {
+                    transform.eulerAngles = new Vector3(
+                    transform.eulerAngles.x,
+                    Mathf.Abs(_target_y_angle),
+                    transform.eulerAngles.z
+                    );
+                } else
+                {
+                    transform.eulerAngles = new Vector3(
+                    transform.eulerAngles.x,
+                    -Mathf.Abs(_target_y_angle),
+                    transform.eulerAngles.z
+                    );
+                }
+                if (_target_y_angle == 0)
+                {
+                    _target_y_angle = 180f;
+                    isIntervteredControl = false;
+                } else
+                {
+                    _target_y_angle = 0f;
+                    isIntervteredControl = true;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/ChangePerspective.cs.meta
+++ b/Assets/Scripts/ChangePerspective.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfe4a5cdb09a5a3499b432a31cf38372
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -7,7 +7,10 @@ using UnityEngine;
 public class Player : MonoBehaviour
 {
 
+    public Transform cameraWorldAxis;
+    public CameraRotation cameraPanningRevertTarget;
     public LevelManager LevelManager;
+    public ChangePerspective isoCamera;
 
     private float _horizontalMovement;
     private float _verticalMovement;
@@ -19,7 +22,8 @@ public class Player : MonoBehaviour
     // Rigid Grid Movement
     public float speed;
     private Vector3 _targetLocation;
-    private Vector3 _prevLocation;
+    private Vector3 _curposition;
+    private Vector3 _prevPosition;
 
     private UpdateUI _updateUI;
     private Transform _transform;
@@ -31,11 +35,16 @@ public class Player : MonoBehaviour
         _rigidbody = gameObject.GetComponent<Rigidbody>();
         _capsuleCollider = gameObject.GetComponent<CapsuleCollider>();
         _targetLocation = transform.position;
-        _prevLocation = _targetLocation;
+        _prevPosition = _targetLocation;
     }
 
     void Update()
     {
+        _curposition = transform.position;
+        Vector3 distMoved = _curposition - _prevPosition;
+        cameraWorldAxis.position = cameraWorldAxis.position + new Vector3(0, distMoved.y, 0);
+        cameraPanningRevertTarget._gameplayPos = cameraPanningRevertTarget._gameplayPos + new Vector3(0, distMoved.y, 0);
+
         if (LevelManager.freeze_player)
         {
             return;
@@ -43,8 +52,8 @@ public class Player : MonoBehaviour
 
         //Debug.DrawRay(_targetLocation + new Vector3(1, -_capsuleCollider.height / 2, 0),
         //    Vector3.up * _capsuleCollider.height, Color.green);
-        _horizontalMovement = Input.GetAxisRaw("Horizontal");
-        _verticalMovement = Input.GetAxisRaw("Vertical");
+        _horizontalMovement = isoCamera.isIntervteredControl ? -Input.GetAxisRaw("Horizontal") : Input.GetAxisRaw("Horizontal");
+        _verticalMovement = isoCamera.isIntervteredControl ? -Input.GetAxisRaw("Vertical") : Input.GetAxisRaw("Vertical");
         _isHorizontalMovementPressed = Input.GetButton("Horizontal");
         _isVerticalMovementPressed = Input.GetButton("Vertical");
 
@@ -53,6 +62,11 @@ public class Player : MonoBehaviour
             _targetLocation.y = transform.position.y;
             RigidGridMove();
         }
+        _prevPosition = _curposition;
+    }
+
+    private void FixedUpdate()
+    {
     }
 
     private void RigidGridMove()
@@ -65,6 +79,9 @@ public class Player : MonoBehaviour
             newPosition = _targetLocation;
             SetNewTargetLocation(newPosition);
         }
+        Vector3 horDistMoved = newPosition - transform.position;
+        cameraWorldAxis.position = cameraWorldAxis.position + horDistMoved;
+        cameraPanningRevertTarget._gameplayPos = cameraPanningRevertTarget._gameplayPos + horDistMoved;
 
         transform.position = newPosition;
 
@@ -96,8 +113,6 @@ public class Player : MonoBehaviour
         {
             return;
         }
-
-        _prevLocation = currentTransformPosition;
 
         switch (pressedButton)
         {
@@ -288,22 +303,22 @@ public class Player : MonoBehaviour
     {
         if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))
         {
-            return "Up";
+            return isoCamera.isIntervteredControl ? "Down" : "Up";
         }
 
         if (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow))
         {
-            return "Down";
+            return isoCamera.isIntervteredControl ? "Up" : "Down";
         }
 
         if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))
         {
-            return "Left";
+            return isoCamera.isIntervteredControl ? "Right" : "Left";
         }
 
         if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow))
         {
-            return "Right";
+            return isoCamera.isIntervteredControl ? "Left" : "Right";
         }
 
         return "";


### PR DESCRIPTION
Major changes:
- press e or q to rotate camera by 180 degrees
- panning now uses middle mouse button instead to simulate controller mapping (panning and moving is separate for the controller, this also fixes a camera snapping bug where previously camera should suddenly move when player moves after changing altitude)
- camera movement detached from the player, wherever you position the camera before the game starts would be the default position of the camera in the game. 
- panning now transitions back to player when done
- panning + rotation + movement all are synchronized, no more camera alignment issues (try combination of all three and see if you can break it)
- controls are inverted based on current camera position

Possible enhancement:
The lighting doesn't change after camera is rotated, causing one side to be dark and the other bright. Attaching the light to camera should fix the issue (future enhancement) 