### PR TITLE
fleshed out checkpoint system and added automatic reset

### DIFF
--- a/Assets/Materials/Player/PaintBottle/Paint.mat
+++ b/Assets/Materials/Player/PaintBottle/Paint.mat
@@ -73,6 +73,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.54901963, g: 0.8235294, b: 0.8039216, a: 1}
+    - _Color: {r: 0.9490196, g: 0.7490196, b: 0.23921569, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/Player/PaintBrush/Tip.mat
+++ b/Assets/Materials/Player/PaintBrush/Tip.mat
@@ -73,6 +73,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.54901963, g: 0.8235294, b: 0.8039216, a: 1}
+    - _Color: {r: 0.9490196, g: 0.7490196, b: 0.23921569, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scenes/AlphaScenev2.unity
+++ b/Assets/Scenes/AlphaScenev2.unity
@@ -52160,9 +52160,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c12cc9dfd0fb97b4abe8bf4fece62b9b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dev_mode: 1
+  dev_mode: 0
   freeze_player: 0
-  is_resetting: 0
   player_script: {fileID: 222737432}
   player: {fileID: 222737430}
   init_yellow: 20
@@ -64798,6 +64797,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4630231336181251400, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4630231336211086034, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}

--- a/Assets/Scenes/TutorialColors.unity
+++ b/Assets/Scenes/TutorialColors.unity
@@ -8113,6 +8113,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 5616881381544338443, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
   m_PrefabInstance: {fileID: 859007759}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &222737432 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+  m_PrefabInstance: {fileID: 859007759}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222737430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad2a0324d78d86e41a0a4bebd96bbbff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &222971230
 GameObject:
   m_ObjectHideFlags: 0
@@ -10927,6 +10938,49 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 331373269}
   m_Mesh: {fileID: -2778385975413223027, guid: 2120b6193e20ea94d912fa460b81b7fb, type: 3}
+--- !u!1 &331756354
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 331756356}
+  - component: {fileID: 331756355}
+  m_Layer: 0
+  m_Name: PaintingSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &331756355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331756354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5b47f4b4c9b4c33a5a42f1ab0d5b273, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &331756356
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331756354}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &332634812
 GameObject:
   m_ObjectHideFlags: 0
@@ -31556,6 +31610,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1704174257}
     - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
+      propertyPath: _colorWheelHUD
+      value: 
+      objectReference: {fileID: 1400497622}
+    - target: {fileID: 5616881381544338440, guid: dac5fd1b427a0804497d9b2456d2af59, type: 3}
       propertyPath: cameraTransform
       value: 
       objectReference: {fileID: 1510057399}
@@ -35767,6 +35825,139 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0.5, z: 0}
+--- !u!1 &982400798
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 982400799}
+  - component: {fileID: 982400802}
+  - component: {fileID: 982400801}
+  - component: {fileID: 982400800}
+  m_Layer: 0
+  m_Name: RestartAtCheckpoint Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &982400799
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982400798}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1883772487}
+  m_Father: {fileID: 1050199760}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -69.99951, y: -32.999878}
+  m_SizeDelta: {x: 236.2917, y: 67.36499}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &982400800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982400798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.13333334, g: 0.13333334, b: 0.13333334, a: 1}
+    m_HighlightedColor: {r: 0.5293254, g: 0.6132076, b: 0.5464125, a: 1}
+    m_PressedColor: {r: 0.37936097, g: 0.5188679, b: 0.40777904, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 982400801}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1704174257}
+        m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
+        m_MethodName: RestartAtLastCheckpoint
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &982400801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982400798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &982400802
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982400798}
+  m_CullTransparentMesh: 1
 --- !u!1 &992805845
 GameObject:
   m_ObjectHideFlags: 0
@@ -50770,6 +50961,11 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1399899045}
   m_Mesh: {fileID: -1750125985355865389, guid: 0065c2c84fb73044d96c36190377389d, type: 3}
+--- !u!1 &1400497622 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4622593199206464746, guid: cc53aeb5d23971a449c22e178fea39c0, type: 3}
+  m_PrefabInstance: {fileID: 1842044549}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1402571324
 GameObject:
   m_ObjectHideFlags: 0
@@ -65661,6 +65857,7 @@ GameObject:
   - component: {fileID: 1704174259}
   - component: {fileID: 1704174261}
   - component: {fileID: 1704174260}
+  - component: {fileID: 1704174263}
   m_Layer: 0
   m_Name: Level
   m_TagString: Untagged
@@ -65694,12 +65891,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dev_mode: 0
   freeze_player: 0
-  player_script: {fileID: 0}
-  player: {fileID: 0}
-  init_yellow: 0
-  init_red: 0
-  init_green: 0
-  init_blue: 0
+  player_script: {fileID: 222737432}
+  player: {fileID: 222737430}
+  init_yellow: 1
+  init_red: 1
+  init_green: 1
+  init_blue: 1
 --- !u!4 &1704174258
 Transform:
   m_ObjectHideFlags: 0
@@ -66007,6 +66204,18 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &1704174263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1704174255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e8f3d1665537ed498e67f7728178358, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1704521596
 GameObject:
   m_ObjectHideFlags: 0
@@ -66524,63 +66733,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0.5, z: 0}
---- !u!1001 &1708582179
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300918, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7027774230117300920, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
-      propertyPath: m_Name
-      value: PaintingSystem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 17e910d45d26ed14c877bd85a6491f3d, type: 3}
 --- !u!1 &1713689636
 GameObject:
   m_ObjectHideFlags: 0
@@ -71765,7 +71917,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4622593199206464746, guid: cc53aeb5d23971a449c22e178fea39c0, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4622593199480283629, guid: cc53aeb5d23971a449c22e178fea39c0, type: 3}
       propertyPath: location
@@ -73605,6 +73757,140 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0.5, z: 0}
+--- !u!1 &1883772486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1883772487}
+  - component: {fileID: 1883772489}
+  - component: {fileID: 1883772488}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1883772487
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883772486}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 982400799}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1883772488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883772486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Load Checkpoint
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4286158528
+  m_fontColor: {r: 0.7529412, g: 0.5882353, b: 0.4745098, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 0
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1883772489
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883772486}
+  m_CullTransparentMesh: 1
 --- !u!1 &1891036514
 GameObject:
   m_ObjectHideFlags: 0
@@ -75089,7 +75375,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1050199760}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -77129,6 +77415,10 @@ PrefabInstance:
     - target: {fileID: 4630231335841536345, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
+      objectReference: {fileID: 1704174256}
+    - target: {fileID: 4630231335841536345, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Restart
       objectReference: {fileID: 0}
     - target: {fileID: 4630231335913717551, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
       propertyPath: m_LocalScale.y
@@ -77228,6 +77518,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4630231336181251400, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4630231336189153379, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4630231336211086034, guid: 55ac21c667e34b34bacccaaed9cff42a, type: 3}
@@ -77837,49 +78159,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2057716882}
   m_Mesh: {fileID: -1750125985355865389, guid: 0065c2c84fb73044d96c36190377389d, type: 3}
---- !u!1 &2059858758
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2059858759}
-  - component: {fileID: 2059858760}
-  m_Layer: 0
-  m_Name: PaintSelectionUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2059858759
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2059858758}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -959.0887, y: -539.9149, z: 1.7183706}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1050199760}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2059858760
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2059858758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e9fc7d1d76544665a8fcd85f12c8adfa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2060160786
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Creatures/RammingCreature.cs
+++ b/Assets/Scripts/Creatures/RammingCreature.cs
@@ -48,7 +48,7 @@ public class RammingCreature : SpecialCreature
     {
         if (collision.gameObject.GetComponent<Ground>())
         {
-            Destroy(collision.gameObject);
+            collision.gameObject.SetActive(false);
         }
     }
 

--- a/Assets/Scripts/Creatures/SpecialCreature.cs
+++ b/Assets/Scripts/Creatures/SpecialCreature.cs
@@ -19,6 +19,7 @@ public abstract class SpecialCreature : Interactable, TooltipObject, Paintable
     {
         base.Start();
         _updateUI = FindObjectOfType<UpdateUI>();
+        ObjectStorage.specialCreatureStorage.Add(this);
     }
 
     protected void OnMouseDown()

--- a/Assets/Scripts/Environment/MoveWall.cs
+++ b/Assets/Scripts/Environment/MoveWall.cs
@@ -7,6 +7,11 @@ public class MoveWall : MonoBehaviour
     public bool operate = false;
     private float end_y = -0.5f;
 
+    private void Start()
+    {
+        ObjectStorage.wallStorage.Add(this.gameObject);
+    }
+
     void Update()
     {
         if (operate == true)

--- a/Assets/Scripts/Environment/PaintOrb.cs
+++ b/Assets/Scripts/Environment/PaintOrb.cs
@@ -48,6 +48,7 @@ public class PaintOrb : Interactable, TooltipObject
         {
             mesh.material.color = newColor;
         }
+        ObjectStorage.paintOrbStorage.Add(this.gameObject);
     }
 
     void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Managers/LevelManager.cs
+++ b/Assets/Scripts/Managers/LevelManager.cs
@@ -56,7 +56,10 @@ public class LevelManager : MonoBehaviour
         LevelManager.pastCheckPoints = new List<Vector3>();
         checkpointInfo = new Dictionary<string, dynamic>();
         checkpointInfo["checkpointPos"] = Vector3.zero;
+        playerPaintBrush = FindObjectOfType<PaintBrush>();
+        playerPaintBottle = FindObjectOfType<PaintBottle>();
     }
+
     void Start()
     {
         StartCoroutine(ManageCoroutines());
@@ -82,8 +85,7 @@ public class LevelManager : MonoBehaviour
         _updateUI = FindObjectOfType<UpdateUI>(); // Auto-sets yellow to 3/10
         _updateUI.SetPaint(paintQuantity["Yellow"]);
 
-        playerPaintBrush = FindObjectOfType<PaintBrush>();
-        playerPaintBottle = FindObjectOfType<PaintBottle>();
+        
 
         _colourChangeSoundManager.SetAudioSources(GetComponents<AudioSource>());
     }
@@ -244,6 +246,41 @@ public class LevelManager : MonoBehaviour
                     block.SetActive(ObjectStorage.blockStates[i][6]);
                 }
             }
+
+            //reset paintOrb attributes
+            for (int i = 0; i < ObjectStorage.paintOrbStorage.Count; i++)
+            {
+                GameObject paintOrb = ObjectStorage.paintOrbStorage[i];
+                paintOrb.transform.position = ObjectStorage.paintOrbStates[i][0];
+                paintOrb.SetActive(ObjectStorage.paintOrbStates[i][1]);
+            }
+
+            //reset specialCreature attributes
+            for (int i = 0; i < ObjectStorage.specialCreatureStorage.Count; i++)
+            {
+                SpecialCreature specialCreature = ObjectStorage.specialCreatureStorage[i];
+                specialCreature.gameObject.transform.position = ObjectStorage.specialCreatureStates[i][0];
+                specialCreature.isPainted = ObjectStorage.specialCreatureStates[i][1];
+                specialCreature.originalColour = ObjectStorage.specialCreatureStates[i][2];
+                specialCreature.paintedColour = ObjectStorage.specialCreatureStates[i][3];
+                specialCreature.GetComponentInChildren<Renderer>().material.color = ObjectStorage.specialCreatureStates[i][3];
+                specialCreature.gameObject.SetActive(ObjectStorage.specialCreatureStates[i][4]);
+            }
+
+            //reset wall attributes
+            for (int i = 0; i < ObjectStorage.wallStorage.Count; i++)
+            {
+                GameObject wall = ObjectStorage.wallStorage[i];
+                wall.transform.position = ObjectStorage.wallStates[i][0];
+                wall.GetComponent<MoveWall>().operate = ObjectStorage.wallStates[i][1];
+            }
+
+            //reset paint amount
+            paintQuantity["Blue"] = ObjectStorage.paintStates[0];
+            paintQuantity["Green"] = ObjectStorage.paintStates[1];
+            paintQuantity["Red"] = ObjectStorage.paintStates[2];
+            paintQuantity["Yellow"] = ObjectStorage.paintStates[3];
+            _updateUI.SetPaint(GetPaintQuantity(GetCurrentlySelectedPaint()));
         }
         actionQueue.Clear();
         StopAllCoroutines();
@@ -293,6 +330,14 @@ public class LevelManager : MonoBehaviour
 
         StopCoroutine("CheckPaintQuantity"); // Stop existing coroutine.
         StartCoroutine("CheckPaintQuantity");
+    }
+
+    public void AddPaintInfoToStorage()
+    {
+        ObjectStorage.paintStates.Add(paintQuantity["Blue"]);
+        ObjectStorage.paintStates.Add(paintQuantity["Green"]);
+        ObjectStorage.paintStates.Add(paintQuantity["Red"]);
+        ObjectStorage.paintStates.Add(paintQuantity["Yellow"]);
     }
 
     private void ClearUIInfoText()

--- a/Assets/Scripts/Managers/ObjectStorage.cs
+++ b/Assets/Scripts/Managers/ObjectStorage.cs
@@ -5,14 +5,25 @@ using UnityEngine;
 public class ObjectStorage : MonoBehaviour
 {
     public static List<GameObject> blockStorage;
+    public static List<GameObject> paintOrbStorage;
+    public static List<SpecialCreature> specialCreatureStorage;
+    public static List<GameObject> wallStorage;
     public static List<List<dynamic>> blockStates;
+    public static List<List<dynamic>> paintOrbStates;
+    public static List<List<dynamic>> specialCreatureStates;
+    public static List<List<dynamic>> wallStates;
+    public static List<dynamic> paintStates;
     void Awake()
     {
         blockStorage = new List<GameObject>();
+        paintOrbStorage = new List<GameObject>();
+        specialCreatureStorage = new List<SpecialCreature>();
+        wallStorage = new List<GameObject>();
+        paintStates = new List<dynamic>();
     }
 
     // Update is called once per frame
-    public static void UpdateStorage()
+    public static void UpdateBlockStorage()
     {
         blockStates = new List<List<dynamic>>();
         foreach (GameObject block in blockStorage)
@@ -27,6 +38,49 @@ public class ObjectStorage : MonoBehaviour
             blockInfo.Add(block.GetComponentInChildren<Renderer>().material.color);
             blockInfo.Add(block.activeSelf);
             blockStates.Add(blockInfo);
+        }
+    }
+
+    public static void UpdatePaintOrbStorage()
+    {
+        paintOrbStates = new List<List<dynamic>>();
+        foreach (GameObject paintOrb in paintOrbStorage)
+        {
+            List<dynamic> paintOrbInfo = new List<dynamic>();
+            paintOrbInfo.Add(paintOrb.transform.position);
+            paintOrbInfo.Add(paintOrb.activeSelf);
+            paintOrbStates.Add(paintOrbInfo);
+        }
+    }
+
+    public static void UpdateSpecialCreatureStorage()
+    {
+        specialCreatureStates = new List<List<dynamic>>();
+        foreach (SpecialCreature specialCreature in specialCreatureStorage)
+        {
+            List<dynamic> specialCreatureInfo = new List<dynamic>();
+            specialCreatureInfo.Add(specialCreature.gameObject.transform.position);
+            //if (specialCreature is HowlingCreature)
+            //{
+            //    specialCreatureInfo.Add(((HowlingCreature)specialCreature).isTriggered);
+            //}
+            specialCreatureInfo.Add(specialCreature.isPainted);
+            specialCreatureInfo.Add(specialCreature.originalColour);
+            specialCreatureInfo.Add(specialCreature.paintedColour);
+            specialCreatureInfo.Add(specialCreature.gameObject.activeSelf);
+            specialCreatureStates.Add(specialCreatureInfo);
+        }
+    }
+
+    public static void UpdateWallStorage()
+    {
+        wallStates = new List<List<dynamic>>();
+        foreach (GameObject wall in wallStorage)
+        {
+            List<dynamic> wallInfo = new List<dynamic>();
+            wallInfo.Add(wall.gameObject.transform.position);
+            wallInfo.Add(wall.GetComponent<MoveWall>().operate);
+            wallStates.Add(wallInfo);
         }
     }
 

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -63,6 +63,11 @@ public class Player : MonoBehaviour
             resetMode = false;
         }
 
+        if (this.gameObject.transform.position.y < -4)
+        {
+            LevelManager.RestartAtLastCheckpoint();
+        }
+
         cameraWorldAxis.position = cameraWorldAxis.position + new Vector3(0, distMoved.y, 0);
         cameraPanningRevertTarget._gameplayPos =
             cameraPanningRevertTarget._gameplayPos + new Vector3(0, distMoved.y, 0);

--- a/Assets/Scripts/UI/UpdateUI.cs
+++ b/Assets/Scripts/UI/UpdateUI.cs
@@ -21,7 +21,7 @@ public class UpdateUI : MonoBehaviour
     private PaintNeededText infoText;
     private bool _alreadyOverriden;
 
-    private void Start()
+    private void Awake()
     {
         paintIcon = FindObjectOfType<PaintBucketIcon>();
         paintBar = FindObjectOfType<PaintLeftBar>();
@@ -41,6 +41,7 @@ public class UpdateUI : MonoBehaviour
 
     private void Update()
     {
+        
         if (_isCrosshairActive)
         {
             Ray ray = _camera.ViewportPointToRay(new Vector3(0.5F, 0.5F, 0));

--- a/Assets/Scripts/checkpoint.cs
+++ b/Assets/Scripts/checkpoint.cs
@@ -22,14 +22,18 @@ public class checkpoint : MonoBehaviour
     {
         if (active)
         {
-            Debug.DrawRay(this.transform.position, Vector3.up * 2, Color.black);
+            //Debug.DrawRay(this.transform.position, Vector3.up * 2, Color.black);
             if (Physics.Raycast(this.transform.position, Vector3.up, out hitInfo, 2, mask))
             {
                 LevelManager.checkpointInfo["checkpointPos"] = this.transform.position;
                 LevelManager.pastCheckPoints.Add(this.transform.position);
                 LevelManager.checkpointInfo["playerRotation"] = hitInfo.transform.rotation;
                 LevelManager.checkpointInfo["cameraAttributes"] = cameraPanningRevertTarget;
-                ObjectStorage.UpdateStorage();
+                FindObjectOfType<LevelManager>().AddPaintInfoToStorage();
+                ObjectStorage.UpdateBlockStorage();
+                ObjectStorage.UpdatePaintOrbStorage();
+                ObjectStorage.UpdateSpecialCreatureStorage();
+                ObjectStorage.UpdateWallStorage();
                 active = false;
             }
         }


### PR DESCRIPTION
Changes:
- Completed checkpoint system, for now there's no visual effect for checkpoint blocks. You can set a block to be a checkpoint by dragging the checkpoint script to the block parent. Only one checkpoint can be active at a time and once it's activated, the progress is saved and the checkpoint is forever deactivated. Press the restart at last checkpoint to load the save.

- If the player falls under the floor by painting the block underneath blue, the game will automatically load the last checkpoint

- Fixed some UI bugs.