### PR TITLE
ISO Camera Rotation Fixes

### DIFF
--- a/Assets/Materials/Player/PaintBottle/Paint.mat
+++ b/Assets/Materials/Player/PaintBottle/Paint.mat
@@ -73,6 +73,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.94509804, g: 0.37254903, b: 0.24313726, a: 1}
+    - _Color: {r: 0.9490196, g: 0.7490196, b: 0.23921569, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/Player/PaintBrush/Tip.mat
+++ b/Assets/Materials/Player/PaintBrush/Tip.mat
@@ -73,6 +73,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.94509804, g: 0.37254903, b: 0.24313726, a: 1}
+    - _Color: {r: 0.9490196, g: 0.7490196, b: 0.23921569, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/Camera/CameraRotation.cs
+++ b/Assets/Scripts/Camera/CameraRotation.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using DefaultNamespace;
 using UnityEngine;
+using static GameConstants;
 
 public class CameraRotation : MonoBehaviour
 {
@@ -71,17 +72,36 @@ public class CameraRotation : MonoBehaviour
             }
             else if ((Input.GetMouseButton(2)))
             {
-                //Note: because panning is detected alongside clicking thus causes jittering when reset, 
-                //      I changed the panning to a separate button as this will reflect our final product
-                // remove this comment once controller support is realized
                 LevelManager.SetIsPanning(true);
                 _wasPanning = true;
                 _panningPos = transform.parent.parent.position;
                 Vector3 distanceMoved = Input.mousePosition - _initialClickPosition;
-                Vector3 rightMovement = right * speed * Time.deltaTime * -distanceMoved.x;
-                Vector3 upMovement = forward * speed * Time.deltaTime * -distanceMoved.y;
-                rightMovement = isoCamera.isIntervteredControl ? -rightMovement : rightMovement;
-                upMovement = isoCamera.isIntervteredControl ? -upMovement : upMovement;
+
+                Vector3 rightMovement = Vector3.zero;
+                Vector3 upMovement = Vector3.zero;
+                switch (isoCamera.direction)
+                {
+                    case CameraDirection.N:
+                        rightMovement = right * speed * Time.deltaTime * -distanceMoved.x;
+                        upMovement = forward * speed * Time.deltaTime * -distanceMoved.y;
+                        break;
+                    case CameraDirection.E:
+                        rightMovement = right * speed * Time.deltaTime * -distanceMoved.y;
+                        upMovement = forward * speed * Time.deltaTime * distanceMoved.x;
+                        break;
+                    case CameraDirection.S:
+                        rightMovement = right * speed * Time.deltaTime * distanceMoved.x;
+                        upMovement = forward * speed * Time.deltaTime * distanceMoved.y;
+                        break;
+                    case CameraDirection.W:
+                        rightMovement = right * speed * Time.deltaTime * distanceMoved.y;
+                        upMovement = forward * speed * Time.deltaTime * -distanceMoved.x;
+                        break;
+                    default:  // Same as CameraDirection.N
+                        rightMovement = right * speed * Time.deltaTime * -distanceMoved.x;
+                        upMovement = forward * speed * Time.deltaTime * -distanceMoved.y;
+                        break;
+                }
 
                 transform.transform.parent.parent.position += rightMovement;
                 transform.transform.parent.parent.position += upMovement;

--- a/Assets/Scripts/Camera/ChangePerspective.cs
+++ b/Assets/Scripts/Camera/ChangePerspective.cs
@@ -34,7 +34,8 @@ public class ChangePerspective : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Q) || _controllerUtil.GetRotationChange() > 0)
+        if (!_changingPersective && (Input.GetKeyDown(KeyCode.Q) ||
+                                     _controllerUtil.GetRotationChange() > 0))
         {
             _changingPersective = true;
             _rot_dest = 90;
@@ -42,7 +43,8 @@ public class ChangePerspective : MonoBehaviour
                 ? _target_y_angle + 90f
                 : 0f;
         }
-        else if (Input.GetKeyDown(KeyCode.E) || _controllerUtil.GetRotationChange() < 0)
+        else if (!_changingPersective && (Input.GetKeyDown(KeyCode.E) ||
+                                          _controllerUtil.GetRotationChange() < 0))
         {
             _changingPersective = true;
             _rot_dest = -90;
@@ -71,7 +73,8 @@ public class ChangePerspective : MonoBehaviour
                         Mathf.Abs(_target_y_angle),
                         transform.eulerAngles.z
                     );
-                } else
+                }
+                else
                 {
                     transform.eulerAngles = new Vector3(
                         transform.eulerAngles.x,

--- a/Assets/Scripts/Managers/ControllerUtil.cs
+++ b/Assets/Scripts/Managers/ControllerUtil.cs
@@ -85,11 +85,6 @@ namespace DefaultNamespace
                     ? -1
                     : 0);
 
-            if (isoCamera.isIntervteredControl)
-            {
-                axis = -axis;
-            }
-
             return FinishedMovementDelay(axis);
         }
 
@@ -106,11 +101,6 @@ namespace DefaultNamespace
                 : (Input.GetAxisRaw("ZAxisPaintSelect") < 0
                     ? -1
                     : 0);
-
-            if (isoCamera.isIntervteredControl)
-            {
-                axis = -axis;
-            }
 
             return FinishedMovementDelay(axis);
         }

--- a/Assets/Scripts/Player/PaintingSystem.cs
+++ b/Assets/Scripts/Player/PaintingSystem.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using DefaultNamespace;
 using UnityEngine;
+using static GameConstants;
 
 public class PaintingSystem : MonoBehaviour
 {
     private Player _player;
     private ControllerUtil _controllerUtil;
+    private ChangePerspective _isoCamera;
 
     private Collider _groundBlockBelowPlayer;
     private Collider _currentlySelectedToPaint;
@@ -34,6 +36,7 @@ public class PaintingSystem : MonoBehaviour
         
         _player = FindObjectOfType<Player>();
         _controllerUtil = FindObjectOfType<ControllerUtil>();
+        _isoCamera = FindObjectOfType<ChangePerspective>();
 
         UpdateGroundBlockBelowPlayer();
         SetCurrentlySelectedObject(_groundBlockBelowPlayer, Vector2.zero);
@@ -95,15 +98,59 @@ public class PaintingSystem : MonoBehaviour
             return;
         }
 
-        if (_controllerUtil.GetXAxisPaintSelectAxis(out int xSelect)
-            && IsWithinRange(_selectedCoordinatesRelToPlayer.x + xSelect, 2))
+        bool xAxisActive = _controllerUtil.GetXAxisPaintSelectAxis(out int xSelect);
+        bool zAxisActive = _controllerUtil.GetZAxisPaintSelectAxis(out int zSelect);
+
+        // Move painting selection indicator based on the direction
+        // the ISO camera is facing
+        if (xAxisActive || zAxisActive)
         {
-            BestEffortUpdateCurrentlySelectedBlock(xSelect == 1 ? Vector3.right : Vector3.left, 1);
-        }
-        else if (_controllerUtil.GetZAxisPaintSelectAxis(out int zSelect)
-                 && IsWithinRange(_selectedCoordinatesRelToPlayer.y + zSelect, 2))
-        {
-            BestEffortUpdateCurrentlySelectedBlock(zSelect == 1 ? Vector3.forward : Vector3.back, 1);
+            switch (_isoCamera.direction)
+            {
+                case CameraDirection.N:
+                    if (xAxisActive && IsWithinRange(_selectedCoordinatesRelToPlayer.x + xSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(xSelect == 1 ? Vector3.right : Vector3.left, 1);
+                    }
+                    else if (IsWithinRange(_selectedCoordinatesRelToPlayer.y + zSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(zSelect == 1 ? Vector3.forward : Vector3.back, 1);
+                    }
+                    break;
+
+                case CameraDirection.E:
+                    if (xAxisActive && IsWithinRange(_selectedCoordinatesRelToPlayer.y - xSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(xSelect == 1 ? Vector3.back : Vector3.forward, 1);
+                    }
+                    else if (IsWithinRange(_selectedCoordinatesRelToPlayer.x + zSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(zSelect == 1 ? Vector3.right : Vector3.left, 1);
+                    }
+                    break;
+
+                case CameraDirection.S:
+                    if (xAxisActive && IsWithinRange(_selectedCoordinatesRelToPlayer.x - xSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(xSelect == 1 ? Vector3.left : Vector3.right, 1);
+                    }
+                    else if (IsWithinRange(_selectedCoordinatesRelToPlayer.y - zSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(zSelect == 1 ? Vector3.back : Vector3.forward, 1);
+                    }
+                    break;
+
+                case CameraDirection.W:
+                    if (xAxisActive && IsWithinRange(_selectedCoordinatesRelToPlayer.y + xSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(xSelect == 1 ? Vector3.forward : Vector3.back, 1);
+                    }
+                    else if (IsWithinRange(_selectedCoordinatesRelToPlayer.x - zSelect, 2))
+                    {
+                        BestEffortUpdateCurrentlySelectedBlock(zSelect == 1 ? Vector3.left : Vector3.right, 1);
+                    }
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
- Make painting selection correspond to camera direction
- Make camera panning work properly regardless of camera direction
- Fix controller camera rotation spinning more than 90 degrees at a time

Closes #86 